### PR TITLE
using var instead of hardcoded value

### DIFF
--- a/gitlab-webhook-receiver
+++ b/gitlab-webhook-receiver
@@ -31,7 +31,7 @@ start () {
 
 stop () {
         echo -n "Stopping $prog"
-        killproc gitlab-webhook-receiver.py
+        killproc $prog
         RETVAL=$?
         [ $RETVAL -eq 0 ] && success || failure
         echo


### PR DESCRIPTION
Using hardcoded value bad when you have more than 1 hook server working on different ports. Killing by name kills every instance.
